### PR TITLE
Disable docs when building jq

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ fn run_autotools(out_dir: &Path) -> Result<Artifacts, ()> {
                 .reconf("-fi")
                 .out_dir(&out)
                 .disable("maintainer-mode", None)
+                .disable("docs", None)
                 .with("oniguruma", Some("builtin"))
                 .make_args(vec!["LDFLAGS=-all-static".into(), "CFLAGS=-fPIC".into()])
                 .build();


### PR DESCRIPTION
It doens't make much of a difference on 1.6, but on master it avoids
having to install pipenv dependencies, which, otherwise, result in
a build error. The jq configure should probably check for the pipenv
dependencies instead of assuming the presence of pipenv means they'll
be installed (in a separate step from the make), but there's no point
in building with docs in this context anyway.